### PR TITLE
Add parentheses around &:not[]

### DIFF
--- a/assets/sass/material/_card.scss
+++ b/assets/sass/material/_card.scss
@@ -132,7 +132,7 @@
 
   .card-body + &,
   .card-header + & {
-    &:not[class*='border-'] {
+    &:not([class*='border-']) {
       padding-top: 0;
     }
 


### PR DESCRIPTION
The Wepbacker Rails component is unable to process the scss file without those parentheses.